### PR TITLE
[im-t2624]: load Barefoot driver with bf_kdrv_mod_load script.

### DIFF
--- a/syncd/scripts/syncd_init_common.sh
+++ b/syncd/scripts/syncd_init_common.sh
@@ -144,7 +144,9 @@ config_syncd_barefoot()
     export PYTHONPATH=/opt/bfn/install/
     export ONIE_PLATFORM=`grep onie_platform /etc/machine.conf | awk 'BEGIN { FS = "=" } ; { print $2 }'`
     export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/bfn/install/lib/platform/$ONIE_PLATFORM:/opt/bfn/install/lib:/opt/bfn/install/lib/tofinopd/switch
+    SDE_INSTALL=/opt/bfn/install/
     ./opt/bfn/install/bin/dma_setup.sh
+    ./opt/bfn/install/bin/bf_kdrv_mod_load $SDE_INSTALL
 }
 
 config_syncd_nephos()


### PR DESCRIPTION
load Barefoot driver with bf_kdrv_mod_load script on cold boot system startup.